### PR TITLE
develop

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 [![View on Github](https://tuftsdatalab.github.io/badges/github.svg)](https://github.com/tuftsdatalab/intro-r)&nbsp;
 [![Download Zip](https://tuftsdatalab.github.io/badges/zip.svg)](https://github.com/tuftsdatalab/intro-r/zipball/workshop)&nbsp;
 [![Download TarGz](https://tuftsdatalab.github.io/badges/tgz.svg)](https://github.com/tuftsdatalab/intro-r/tarball/workshop)&nbsp;
+![download size](https://img.shields.io/github/repo-size/tuftsdatalab/intro-r?label=download%20size)&nbsp;
 ![last updated](https://img.shields.io/github/last-commit/tuftsdatalab/intro-r?label=last%20updated)
 
 **A Tufts University Data Lab Workshop**\


### PR DESCRIPTION
- restructure repository for copybara
- remove postbuild script
- add copybara workflow for branch population
- reconfigure binder build trigger workflow
- update website links to reflect new repo configuration
- use go links instead of hardcoded redirects
- rename workshop script to conform with wickham style guide
- add website url to workshop script
- remove size badge
- fix installation instructions link
- add download size badge to website
