### PR TITLE
develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,4 @@
 
 Source repository for the following [Tufts University Data Lab](https://sites.tufts.edu/datalab/) workshop: [*A Gentle Introduction to R*](https://tuftsdatalab.github.io/intro-r/)
 
-**Please see the [workshop website](https://tuftsdatalab.github.io/intro-r/) for content.** The following is a development guide.
-
-Repository administrator: [@ukukas](https://github.com/ukukas/)
+**Please see the [workshop website](https://tuftsdatalab.github.io/intro-r/) for content.** The following is a development guide intended for staff.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![workshop website](https://img.shields.io/website?label=workshop%20webiste&url=https%3A%2F%2Ftuftsdatalab.github.io%2Fintro-r%2F)](https://tuftsdatalab.github.io/intro-r/)
 [![mirror content](https://img.shields.io/github/workflow/status/tuftsdatalab/intro-r/mirror-content?label=mirror%20content)](https://github.com/tuftsdatalab/intro-r/actions/workflows/mirror-content.yml)
 [![build binder](https://img.shields.io/github/workflow/status/tuftsdatalab/intro-r/build-binder?label=build%20binder)](https://github.com/tuftsdatalab/intro-r/actions/workflows/build-binder.yml)
-[![license](https://img.shields.io/github/license/tuftsdatalab/intro-r)](https://github.com/tuftsdatalab/intro-r/blob/main/LICENSE.txt)
 [![last commit](https://img.shields.io/github/last-commit/tuftsdatalab/intro-r)](https://github.com/tuftsdatalab/intro-r/commits/main)
 
 Source repository for the following [Tufts University Data Lab](https://sites.tufts.edu/datalab/) workshop: [*A Gentle Introduction to R*](https://tuftsdatalab.github.io/intro-r/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 [![View on Github](https://tuftsdatalab.github.io/badges/github.svg)](https://github.com/tuftsdatalab/intro-r)&nbsp;
 [![Download Zip](https://tuftsdatalab.github.io/badges/zip.svg)](https://github.com/tuftsdatalab/intro-r/zipball/workshop)&nbsp;
 [![Download TarGz](https://tuftsdatalab.github.io/badges/tgz.svg)](https://github.com/tuftsdatalab/intro-r/tarball/workshop)&nbsp;
-[![license](https://img.shields.io/github/license/tuftsdatalab/intro-r)](https://github.com/tuftsdatalab/intro-r/blob/main/LICENSE.txt)&nbsp;
 ![last updated](https://img.shields.io/github/last-commit/tuftsdatalab/intro-r?label=last%20updated)
 
 **A Tufts University Data Lab Workshop**\

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,17 +5,15 @@
 ![last updated](https://img.shields.io/github/last-commit/tuftsdatalab/intro-r?label=last%20updated)
 
 **A Tufts University Data Lab Workshop**\
-Written by Uku-Kaspar Uustalu
+Written by Uku-Kaspar Uustalu and Kyle Monahan
 
 [![datalab.tufts.edu](https://tuftsdatalab.github.io/badges/datalab.svg)](https://sites.tufts.edu/datalab)&nbsp;
 [![@TuftsDataLab](https://tuftsdatalab.github.io/badges/twitter.svg)](https://twitter.com/intent/follow?screen_name=tuftsdatalab)
 
 R resources: [go.tufts.edu/stats](https://go.tufts.edu/stats)\
-Questions: <datalab-support@elist.tufts.edu>\
-Feedback: <uku-kaspar.uustalu@tufts.edu>
-
 Slides: [tufts.box.com/v/intro-r-slides](https://tufts.box.com/v/intro-r-slides)\
-Live offerings: [go.tufts.edu/workshops](https://go.tufts.edu/workshops)
+Live offerings: [go.tufts.edu/workshops](https://go.tufts.edu/workshops)\
+Contact: <datalab-support@elist.tufts.edu>
 
 ---
 This is an introductory R workshop designed for use in an instructor-guided session, but that is also suitable for self-guided study. The workshop can be run both locally or in a cloud-computing environment. Please select the most suitable option for you from below.


### PR DESCRIPTION
- remove datalab email from development guide
- use built-in github token to authenticate workflow
- remove donwload size badges
- add license badge with link to license.txt
- remove license badges
- minor updates to readme
- reconfigure website header section
